### PR TITLE
chore: upgrade to Java 24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use the official Maven image as the base image
-ARG JAVA_VERSION=17
+ARG JAVA_VERSION=24
 FROM maven:3.8.4-openjdk-${JAVA_VERSION} AS builder
 
 # Set the working directory in the container

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <name>relia-bill</name>
     <description>Demo project for Spring Boot</description>
     <properties>
-        <java.version>17</java.version>
+        <java.version>24</java.version>
     </properties>
     <dependencies>
         <dependency>

--- a/system.properties
+++ b/system.properties
@@ -1,1 +1,1 @@
-java.runtime.version=17
+java.runtime.version=24


### PR DESCRIPTION
## Summary
- update Maven configuration to target Java 24
- switch Docker image and runtime properties to Java 24

## Testing
- `sh mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ab38d5ff088323bb605e03da2419ec